### PR TITLE
Add 10-minute timeout to deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ jobs:
     ssh-deploy:
         name: Production
         runs-on: ubuntu-latest
+        timeout-minutes: 10
 
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
Add `timeout-minutes: 10` to the Production `ssh-deploy` job in `.github/workflows/deploy.yml` to cap the workflow runtime and prevent long-running or hung deployments.